### PR TITLE
Add `Format` support to client `GetData` API

### DIFF
--- a/Client/src/init.lua
+++ b/Client/src/init.lua
@@ -15,6 +15,8 @@ local RunService = game:GetService("RunService")
 ------------------
 -- Dependencies --
 ------------------
+local RobloxLibModules = require(script.Parent["roblox-libmodules"])
+local Table = require(RobloxLibModules.Utils.Table)
 local DataService;
 
 -------------
@@ -35,9 +37,31 @@ end
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- @Name : GetData
 -- @Description : Gets the player's data
--- @Params : bool "YieldForLoad" - A bool describing whether or not the API will yield for the data to exist
+-- @Params : OPTIONAL bool "YieldForLoad" - A bool describing whether or not the API will yield for the data to exist
+--           OPTIONAL string "Format" - The format to return the data in. Acceptable formats are "Table" and "Folder".
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-function DataController:GetData(YieldForLoad)
+function DataController:GetData(YieldForLoad,Format)
+
+	if YieldForLoad ~= nil then
+		assert(
+			typeof(YieldForLoad) == "boolean",
+			("[Data Service](GetData) Bad argument #2 to 'GetData', bool expected, got %s instead.")
+			:format(typeof(YieldForLoad))
+		)
+	end
+	if Format ~= nil then
+		assert(
+			typeof(Format) == "string",
+			("[Data Service](GetData) Bad argument #3 to 'GetData', string expected, got %s instead.")
+			:format(typeof(Format))
+		)
+		assert(
+			string.upper(Format) == "FOLDER" or string.upper(Format) == "TABLE",
+			("[Data Service](GetData) Bad argument #3 to 'GetData', invalid format. Valid formats are 'Table' or 'Folder', got '%s' instead.")
+			:format(Format)
+		)
+	end
+
 	if YieldForLoad then
 		while true do
 			if self:IsDataLoaded() then
@@ -48,7 +72,13 @@ function DataController:GetData(YieldForLoad)
 		end
 	end
 
-	return PlayerData,PlayerData:GetAttributes()
+	if Format == nil then
+		return PlayerData,PlayerData:GetAttributes()
+	elseif string.upper(Format) == "TABLE" then
+		return Table.ConvertFolderToTable(PlayerData),PlayerData:GetAttributes()
+	elseif string.upper(Format) == "FOLDER" then
+		return PlayerData,PlayerData:GetAttributes()
+	end
 end
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/Client/wally.toml
+++ b/Client/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phoenixentertainment/playerdatasystem-client"
 description = "Player data system client"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Noble_Draconian"]
 realm = "shared"
 registry = "https://github.com/UpliftGames/wally-index"

--- a/Server/wally.toml
+++ b/Server/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phoenixentertainment/playerdatasystem-server"
 description = "Player data system server"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Noble_Draconian"]
 realm = "server"
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
This PR adds a feature to the client's `GetData` API that allows it to return the player's data in different formats (folder or table). This makes it consistent with the server's `GetData` API.